### PR TITLE
Add configs to limit sharing to own group

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -56,6 +56,13 @@ config_apps() {
 	ooc config:app:set --value no files_sharing incoming_server2server_group_share_enabled
 	ooc config:app:set --value no files_sharing lookupServerEnabled
 	ooc config:app:set --value no files_sharing lookupServerUploadEnabled
+
+	echo "Configure internal share settings"
+	# To limit user and group display in the username search field of the
+	# Share panel to list only users with the same group. Groups should not
+	# "see" each other. Users in one contract are part of one group.
+	ooc config:app:set --value="no" core shareapi_only_share_with_group_members
+	ooc config:app:set --value='["admin"]' core shareapi_only_share_with_group_members_exclude_group_list
 }
 
 add_config_partials() {


### PR DESCRIPTION
In the core setttings UI the settings could be found under **Settings** > **Adminstration** > **Sharing**

* enable "Allow sharing with groups"
* list "admin" under "Ignore the following groups when checking group membership"

This affects what users can be found in the share dialog (figure icon) "Search for share recipients".

Since the core settings app is disabled, we configure this hard coded.

**This user input field is meant:**

![image](https://github.com/user-attachments/assets/14dc802f-7216-45de-81e5-f36f49eafe3a)

(Note: users from group 2 are not listed, the lower two users are in all groups)
