### PR TITLE
feat(make): add build_vue_icons_package, build_nc_server_frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ help: ## This help.
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .DEFAULT_GOAL := help
 
-build_nextcloud: ## Build Nextcloud
+build_vue_icons_package: ## Build custom vue icons package
+	cd custom-npms/nc-vue-material-design-icons && \
+	FONTAWESOME_PACKAGE_TOKEN=$(FONTAWESOME_PACKAGE_TOKEN) npm ci && \
+	npm run build
+
+build_nextcloud: build_vue_icons_package ## Build Nextcloud
 	composer install --no-dev -o && \
 	npm ci && \
 	npm run build


### PR DESCRIPTION
in order to be able to build with custom vue icons

Can be executed locally via `make -f IONOS/Makefile build_nextcloud FONTAWESOME_PACKAGE_TOKEN=<FONTAWESOME_PACKAGE_TOKEN>`