### PR TITLE
fix(apps-enable-order): enforce same order of apps to enable

### DIFF
--- a/apps-enable.sh
+++ b/apps-enable.sh
@@ -28,7 +28,7 @@ enable_apps() {
 
 	echo "Enable apps in folder ${apps_dir} ..."
 
-	for app in $( find "${apps_dir}" -mindepth 1 -maxdepth 1 -type d); do
+	for app in $( find "${apps_dir}" -mindepth 1 -maxdepth 1 -type d | sort); do
 		app_name="$( basename "${app}" )"
 		echo "Enable app '${app_name}' ..."
 


### PR DESCRIPTION
"find" command delivers different sorting order on different hosts (containers). Do addition in order to ensure same apps activation order

Before:
```shell
$ find "./apps-custom/" -mindepth 1 -maxdepth 1 -type d
./apps-custom/simplesettings
./apps-custom/googleanalytics
```

After:
```shell
$ find "./apps-custom/" -mindepth 1 -maxdepth 1 -type d | sort
./apps-custom/googleanalytics
./apps-custom/simplesettings
```