### PR TITLE
feat(config): remove "sharebymail" from disabled apps

### DIFF
--- a/disabled-apps.inc.sh
+++ b/disabled-apps.inc.sh
@@ -13,7 +13,6 @@ privacy
 recommendations
 related_resources
 serverinfo
-sharebymail
 support
 survey_client
 systemtags


### PR DESCRIPTION
This app is needed to allow sending share links by email.