### PR TITLE
Configs and scripts required to enable custom mailing and disable internal mailing

### DIFF
--- a/configs/mail.config.php
+++ b/configs/mail.config.php
@@ -1,0 +1,7 @@
+<?php
+
+$CONFIG = [
+	// Disable mailing altogether
+	// Requires Nextcloud server PR #48977
+	'mail_smtpmode' => 'null',
+];


### PR DESCRIPTION
* Set instance config to disable default/core mailing implementation
  * Depends on:
    * https://github.com/nextcloud/server/pull/48977 
    * https://github.com/IONOS-Productivity/nc-server/pull/49

**Note:** we can add the config of the endpoint URL for our custom mailer with this PR too.