### PR TITLE
feat(config): disable appstoreenabled

### DIFF
--- a/configs/disable-automatic-updates.config.php
+++ b/configs/disable-automatic-updates.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = [
+	'appstoreenabled' => false,
+];


### PR DESCRIPTION
Attempt to disable automatic update of apps during deployments/upgrades.

Since we bundle apps with the application to stick with a certain version, we do not expect the apps to be upgraded during instance upgrades.

Refs: ##555