### PR TITLE
chore(Makefile): don't package vendor-bin directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ zip_dependencies: ## Zip relevant files
 	-x "apps-*/*/.github" \
 	-x "apps-*/*/src**" \
 	-x "apps-*/*/node_modules**" \
+	-x "apps-*/*/vendor-bin**" \
 	-x "apps-*/*/tests**" \
 	-x "**/cypress/**" \
 	-x "*.git*" \


### PR DESCRIPTION
They only contain build tools but contribute a lot of size to the package.

* The release.zip was quickly tested locally. Good :heavy_check_mark: 
* Official addons do not package this directory too :heavy_check_mark: