### PR TITLE
feat(user-oidc): set multiple-user-backends to false

### DIFF
--- a/configs/oidc.config.php
+++ b/configs/oidc.config.php
@@ -12,5 +12,6 @@ $CONFIG = [
 	// Update *existing information* in Nextcloud backend
 	// (false = fail login if existing in other backend)
 	'soft_auto_provision' => false,
+	'allow_multiple_user_backends' => false,
   ],
 ];


### PR DESCRIPTION
See
https://github.com/nextcloud/user_oidc?tab=readme-ov-file#disable-other-login-methods