### PR TITLE
fix(user_oidc): correct typo

### DIFF
--- a/configure-user-oidc.sh
+++ b/configure-user-oidc.sh
@@ -16,6 +16,7 @@ configure_user_oidc() {
 		--clientsecret="${ENC_OIDC_SECRET}" \
 		--discoveryuri="${ENC_OIDC_DISCOVERY_URI}" \
 		--endsessionendpointuri="${HDN_OIDC_ENDSESSIONENDPOINT_URI}" \
+		--mapping-uid="${ENC_OIDC_MAPPING_UID}" \
 		--unique-uid=0 \
 		--scope="${ENC_OIDC_SCOPES}"
 
@@ -61,6 +62,10 @@ main() {
 
 	if [ -z "${HDN_OIDC_ENDSESSIONENDPOINT_URI}" ]; then
 		fail "HDN_OIDC_ENDSESSIONENDPOINT_URI not set"
+	fi
+
+	if [ -z "${ENC_OIDC_MAPPING_UID}" ]; then
+		fail "ENC_OIDC_MAPPING_UID not set"
 	fi
 
 	if [ -z "${ENC_OIDC_SCOPES}" ]; then

--- a/configure-user-oidc.sh
+++ b/configure-user-oidc.sh
@@ -11,7 +11,7 @@ configure_user_oidc() {
 	# which leads to the user_oidc not being used during runtime.
 	#
 	# https://github.com/nextcloud/user_oidc/blob/v5.0.3/lib/Service/LocalIdService.php#L30
-	./occ user_oidc:provider "${ENC_OIDC_PROVIDER_IDENTIFIER}}" \
+	./occ user_oidc:provider "${ENC_OIDC_PROVIDER_IDENTIFIER}" \
 		--clientid="${ENC_OIDC_CLIENT_ID}" \
 		--clientsecret="${ENC_OIDC_SECRET}" \
 		--discoveryuri="${ENC_OIDC_DISCOVERY_URI}" \

--- a/configure-user-oidc.sh
+++ b/configure-user-oidc.sh
@@ -15,6 +15,7 @@ configure_user_oidc() {
 		--clientid="${ENC_OIDC_CLIENT_ID}" \
 		--clientsecret="${ENC_OIDC_SECRET}" \
 		--discoveryuri="${ENC_OIDC_DISCOVERY_URI}" \
+		--extra-claims="${ENC_OIDC_EXTRA_CLAIMS}" \
 		--endsessionendpointuri="${HDN_OIDC_ENDSESSIONENDPOINT_URI}" \
 		--mapping-uid="${ENC_OIDC_MAPPING_UID}" \
 		--unique-uid=0 \
@@ -58,6 +59,10 @@ main() {
 
 	if [ -z "${ENC_OIDC_DISCOVERY_URI}" ]; then
 		fail "ENC_OIDC_DISCOVERY_URI not set"
+	fi
+
+	if [ -z "${ENC_OIDC_EXTRA_CLAIMS}" ]; then
+		fail "ENC_OIDC_EXTRA_CLAIMS not set"
 	fi
 
 	if [ -z "${HDN_OIDC_ENDSESSIONENDPOINT_URI}" ]; then

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# IONOS EasyStorage configuration
+# IONOS HiDrive Next configuration
 
 ## Building apps and themes for local development
 


### PR DESCRIPTION
Correct typo. One “}” was too much