### PR TITLE
Revert "feat(oidc): add logout target uri"

### DIFF
--- a/configure-user-oidc.sh
+++ b/configure-user-oidc.sh
@@ -16,7 +16,6 @@ configure_user_oidc() {
 		--clientsecret="${ENC_OIDC_SECRET}" \
 		--discoveryuri="${ENC_OIDC_DISCOVERY_URI}" \
 		--extra-claims="${ENC_OIDC_EXTRA_CLAIMS}" \
-		--endsessionendpointuri="${HDN_OIDC_ENDSESSIONENDPOINT_URI}" \
 		--mapping-uid="${ENC_OIDC_MAPPING_UID}" \
 		--unique-uid=0 \
 		--scope="${ENC_OIDC_SCOPES}"
@@ -63,10 +62,6 @@ main() {
 
 	if [ -z "${ENC_OIDC_EXTRA_CLAIMS}" ]; then
 		fail "ENC_OIDC_EXTRA_CLAIMS not set"
-	fi
-
-	if [ -z "${HDN_OIDC_ENDSESSIONENDPOINT_URI}" ]; then
-		fail "HDN_OIDC_ENDSESSIONENDPOINT_URI not set"
 	fi
 
 	if [ -z "${ENC_OIDC_MAPPING_UID}" ]; then


### PR DESCRIPTION
See user_oidc LoginController.php, singleLogoutService(): the session endpoint URL is provided by the ID server discovery.

This reverts commit 7f71cec5e25eb98fc09ad3dcc70ba9c2673fcaa6.