### PR TITLE
feat(ci): cherry-pick CI/quality workflows from ncw-server

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 root = true
 
 [*]
@@ -6,8 +9,25 @@ end_of_line = lf
 indent_size = 4
 indent_style = tab
 insert_final_newline = true
-max_line_length = 120
 tab_width = 4
 
 [{*.bash,*.sh,*.zsh}]
 indent_size = 2
+
+[{*.json,*.md}]
+indent_size = 2
+indent_style = space
+
+[*.list]
+# List files: one item per line, shell-style comments with #
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[{*.yaml,*.yml}]
+indent_size = 2
+indent_style = space
+
+[LICENSES/**]
+insert_final_newline = unset
+indent_style = unset

--- a/.github/check-shell-config.sh
+++ b/.github/check-shell-config.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Check for config:system:set usage in shell scripts
+# This script ensures shell scripts don't use system-wide configuration commands
+# which can cause conflicts and instability.
+
+set -e
+
+readonly SCRIPT_NAME="check-shell-config.sh"
+readonly CONFIG_COMMAND="config:system:set"
+readonly SUCCESS_EMOJI="✅"
+readonly ERROR_EMOJI="❌"
+readonly WARNING_EMOJI="🚨"
+readonly FIX_EMOJI="📝"
+readonly CHECKLIST_EMOJI="📋"
+
+# Global variables
+found_violations=0
+temp_file=""
+
+# Cleanup function
+cleanup() {
+    if [[ -n "$temp_file" && -f "$temp_file" ]]; then
+        rm -f "$temp_file"
+    fi
+}
+
+# Set up cleanup trap
+trap cleanup EXIT
+
+# Print success message
+print_success() {
+    echo "$SUCCESS_EMOJI SUCCESS: $1"
+}
+
+# Print error message
+print_error() {
+    echo "$ERROR_EMOJI ERROR: $1"
+}
+
+# Print workflow failure message
+print_workflow_failure() {
+    echo "$ERROR_EMOJI WORKFLOW FAILED: $1"
+}
+
+# Check if shell scripts exist in the workspace
+check_shell_scripts_exist() {
+    if ! find . -name "*.sh" -type f | head -1 > /dev/null; then
+        print_success "No shell script files (.sh) found to check"
+        return 1
+    fi
+    return 0
+}
+
+# Check if file should be skipped
+should_skip_file() {
+    local file="$1"
+    [[ "$(basename "$file")" == "$SCRIPT_NAME" ]]
+}
+
+# Find violations in a file
+find_violations_in_file() {
+    local file="$1"
+
+    # Get lines with config:system:set but exclude our detection logic
+    grep -n "$CONFIG_COMMAND" "$file" 2>/dev/null | \
+        grep -v "Check if this is a $CONFIG_COMMAND" | \
+        grep -v "log_warning.*$CONFIG_COMMAND" | \
+        grep -v "if.*$CONFIG_COMMAND" || true
+}
+
+# Report violations for a file
+report_violations() {
+    local file="$1"
+    local violations="$2"
+
+    print_error "Found $CONFIG_COMMAND usage in: $file"
+    echo "   Lines containing $CONFIG_COMMAND:"
+
+    echo "$violations" | while IFS=: read -r line_num content; do
+        echo "     Line $line_num: $content"
+    done
+
+    echo ""
+    echo "   $FIX_EMOJI FIX PROPOSAL:"
+    echo "   - Use partial configuration approach instead of $CONFIG_COMMAND"
+    echo "   - Consider using environment variables or app-specific configuration"
+    echo ""
+
+    # Record violation
+    echo "1" >> "$temp_file"
+}
+
+# Process a single shell script file
+process_file() {
+    local file="$1"
+
+    if should_skip_file "$file"; then
+        return 0
+    fi
+
+    echo "Checking file: $file"
+
+    local violations
+    violations=$(find_violations_in_file "$file")
+
+    if [[ -n "$violations" ]]; then
+        report_violations "$file" "$violations"
+    fi
+}
+
+# Count total violations
+count_violations() {
+    if [[ -f "$temp_file" ]]; then
+        wc -l < "$temp_file"
+    else
+        echo "0"
+    fi
+}
+
+# Print final failure report
+print_failure_report() {
+    local violation_count="$1"
+
+    print_workflow_failure "Found $violation_count file(s) with $CONFIG_COMMAND usage"
+    echo ""
+    echo "$WARNING_EMOJI POLICY VIOLATION:"
+    echo "   $CONFIG_COMMAND should be avoided in favor of partial configuration"
+    echo ""
+    echo "$CHECKLIST_EMOJI RECOMMENDED ACTIONS:"
+    echo "   1. Review each occurrence and determine if it's truly necessary"
+    echo "   2. Replace with config:app:set where possible"
+    echo "   3. Use environment variables for dynamic configuration"
+    echo ""
+}
+
+# Main execution function
+main() {
+    echo "Scanning for $CONFIG_COMMAND usage in shell scripts..."
+
+    # Create temporary file for tracking violations
+    temp_file=$(mktemp)
+
+    # Check if any shell scripts exist
+    if ! check_shell_scripts_exist; then
+        exit 0
+    fi
+
+    # Process all shell script files
+    while IFS= read -r -d '' file; do
+        process_file "$file"
+    done < <(find . -name "*.sh" -type f -print0)
+
+    # Count and report violations
+    found_violations=$(count_violations)
+
+    if [[ "$found_violations" -gt 0 ]]; then
+        print_failure_report "$found_violations"
+        exit 1
+    else
+        print_success "No $CONFIG_COMMAND usage found in shell scripts"
+    fi
+}
+
+# Run main function
+main "$@"

--- a/.github/check-shell-config.sh
+++ b/.github/check-shell-config.sh
@@ -22,9 +22,9 @@ temp_file=""
 
 # Cleanup function
 cleanup() {
-    if [[ -n "$temp_file" && -f "$temp_file" ]]; then
-        rm -f "$temp_file"
-    fi
+		if [[ -n "$temp_file" && -f "$temp_file" ]]; then
+				rm -f "$temp_file"
+		fi
 }
 
 # Set up cleanup trap
@@ -32,136 +32,133 @@ trap cleanup EXIT
 
 # Print success message
 print_success() {
-    echo "$SUCCESS_EMOJI SUCCESS: $1"
+		echo "$SUCCESS_EMOJI SUCCESS: $1"
 }
 
 # Print error message
 print_error() {
-    echo "$ERROR_EMOJI ERROR: $1"
+		echo "$ERROR_EMOJI ERROR: $1"
 }
 
 # Print workflow failure message
 print_workflow_failure() {
-    echo "$ERROR_EMOJI WORKFLOW FAILED: $1"
+		echo "$ERROR_EMOJI WORKFLOW FAILED: $1"
 }
 
 # Check if shell scripts exist in the workspace
 check_shell_scripts_exist() {
-    if ! find . -name "*.sh" -type f | head -1 > /dev/null; then
-        print_success "No shell script files (.sh) found to check"
-        return 1
-    fi
-    return 0
+		if ! find . -name "*.sh" -type f -print -quit | grep -q .; then
+				print_success "No shell script files (.sh) found to check"
+				return 1
+		fi
+		return 0
 }
 
 # Check if file should be skipped
 should_skip_file() {
-    local file="$1"
-    [[ "$(basename "$file")" == "$SCRIPT_NAME" ]]
+		local file="$1"
+		[[ "$(basename "$file")" == "$SCRIPT_NAME" ]]
 }
 
 # Find violations in a file
 find_violations_in_file() {
-    local file="$1"
+		local file="$1"
 
-    # Get lines with config:system:set but exclude our detection logic
-    grep -n "$CONFIG_COMMAND" "$file" 2>/dev/null | \
-        grep -v "Check if this is a $CONFIG_COMMAND" | \
-        grep -v "log_warning.*$CONFIG_COMMAND" | \
-        grep -v "if.*$CONFIG_COMMAND" || true
+		# Get lines with config:system:set; should_skip_file already excludes this script
+		grep -n "$CONFIG_COMMAND" "$file" 2>/dev/null || true
 }
 
 # Report violations for a file
 report_violations() {
-    local file="$1"
-    local violations="$2"
+		local file="$1"
+		local violations="$2"
 
-    print_error "Found $CONFIG_COMMAND usage in: $file"
-    echo "   Lines containing $CONFIG_COMMAND:"
+		print_error "Found $CONFIG_COMMAND usage in: $file"
+		echo "   Lines containing $CONFIG_COMMAND:"
 
-    echo "$violations" | while IFS=: read -r line_num content; do
-        echo "     Line $line_num: $content"
-    done
+		echo "$violations" | while IFS=: read -r line_num content; do
+				echo "     Line $line_num: $content"
+		done
 
-    echo ""
-    echo "   $FIX_EMOJI FIX PROPOSAL:"
-    echo "   - Use partial configuration approach instead of $CONFIG_COMMAND"
-    echo "   - Consider using environment variables or app-specific configuration"
-    echo ""
+		echo ""
+		echo "   $FIX_EMOJI FIX PROPOSAL:"
+		echo "   - Use partial configuration approach instead of $CONFIG_COMMAND"
+		echo "   - Consider using environment variables or app-specific configuration"
+		echo ""
 
-    # Record violation
-    echo "1" >> "$temp_file"
+		# Record violation
+		echo "1" >> "$temp_file"
 }
 
 # Process a single shell script file
 process_file() {
-    local file="$1"
+		local file="$1"
 
-    if should_skip_file "$file"; then
-        return 0
-    fi
+		if should_skip_file "$file"; then
+				return 0
+		fi
 
-    echo "Checking file: $file"
+		echo "Checking file: $file"
 
-    local violations
-    violations=$(find_violations_in_file "$file")
+		local violations
+		violations=$(find_violations_in_file "$file")
 
-    if [[ -n "$violations" ]]; then
-        report_violations "$file" "$violations"
-    fi
+		if [[ -n "$violations" ]]; then
+				report_violations "$file" "$violations"
+		fi
 }
 
 # Count total violations
 count_violations() {
-    if [[ -f "$temp_file" ]]; then
-        wc -l < "$temp_file"
-    else
-        echo "0"
-    fi
+		if [[ -f "$temp_file" ]]; then
+				wc -l < "$temp_file"
+		else
+				echo "0"
+		fi
 }
 
 # Print final failure report
 print_failure_report() {
-    local violation_count="$1"
+		local violation_count="$1"
 
-    print_workflow_failure "Found $violation_count file(s) with $CONFIG_COMMAND usage"
-    echo ""
-    echo "$WARNING_EMOJI POLICY VIOLATION:"
-    echo "   $CONFIG_COMMAND should be avoided in favor of partial configuration"
-    echo ""
-    echo "$CHECKLIST_EMOJI RECOMMENDED ACTIONS:"
-    echo "   1. Review each occurrence and determine if it's truly necessary"
-    echo "   2. Replace with config:app:set where possible"
-    echo "   3. Use environment variables for dynamic configuration"
-    echo ""
+		print_workflow_failure "Found $violation_count file(s) with $CONFIG_COMMAND usage"
+		echo ""
+		echo "$WARNING_EMOJI POLICY VIOLATION:"
+		echo "   $CONFIG_COMMAND should be avoided in favor of partial configuration"
+		echo ""
+		echo "$CHECKLIST_EMOJI RECOMMENDED ACTIONS:"
+		echo "   1. Review each occurrence and determine if it's truly necessary"
+		echo "   2. Replace with config:app:set where possible"
+		echo "   3. Use environment variables for dynamic configuration"
+		echo ""
 }
 
 # Main execution function
 main() {
-    echo "Scanning for $CONFIG_COMMAND usage in shell scripts..."
+		echo "Scanning for $CONFIG_COMMAND usage in shell scripts..."
 
-    # Create temporary file for tracking violations
-    temp_file=$(mktemp)
+		# Create temporary file for tracking violations
+		temp_file=$(mktemp)
 
-    # Check if any shell scripts exist
-    if ! check_shell_scripts_exist; then
-        exit 0
-    fi
+		# Check if any shell scripts exist
+		if ! check_shell_scripts_exist; then
+				exit 0
+		fi
 
-    # Process all shell script files
-    while IFS= read -r -d '' file; do
-        process_file "$file"
-    done < <(find . -name "*.sh" -type f -print0)
+		# Process all shell script files
+		while IFS= read -r -d '' file; do
+				process_file "$file"
+		done < <(find . -name "*.sh" -type f -print0)
 
-    # Count and report violations
-    found_violations=$(count_violations)
+		# Count and report violations
+		found_violations=$(count_violations)
 
-    if [[ "$found_violations" -gt 0 ]]; then
-        print_failure_report "$found_violations"
-        exit 1
-    else
-        print_success "No $CONFIG_COMMAND usage found in shell scripts"
-    fi
+		if [[ "$found_violations" -gt 0 ]]; then
+				print_failure_report "$found_violations"
+				exit 1
+		else
+				print_success "No $CONFIG_COMMAND usage found in shell scripts"
+		fi
 }
 
 # Run main function

--- a/.github/workflows/block-unconventional-commits.yml
+++ b/.github/workflows/block-unconventional-commits.yml
@@ -1,0 +1,36 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Block unconventional commits
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: block-unconventional-commits-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  block-unconventional-commits:
+    name: Block unconventional commits
+
+    runs-on: ubuntu-latest-low
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/block-unconventional-commits.yml
+++ b/.github/workflows/block-unconventional-commits.yml
@@ -23,7 +23,7 @@ jobs:
   block-unconventional-commits:
     name: Block unconventional commits
 
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -1,0 +1,36 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Block fixup and squash commits
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fixup-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  commit-message-check:
+    if: github.event.pull_request.draft == false
+
+    permissions:
+      pull-requests: write
+    name: Block fixup and squash commits
+
+    runs-on: ubuntu-latest-low
+
+    steps:
+      - name: Run check
+        uses: skjnldsv/block-fixup-merge-action@c138ea99e45e186567b64cf065ce90f7158c236a # v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     name: Block fixup and squash commits
 
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
 
     steps:
       - name: Run check

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,27 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  reuse-compliance-check:
+    runs-on: ubuntu-latest-low
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5.0.0

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   reuse-compliance-check:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/shell-config-check.yml
+++ b/.github/workflows/shell-config-check.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Shell Script Configuration Check
+
+on:
+    pull_request:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: shell-script-config-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+  check-config-system-set:
+    runs-on: ubuntu-latest
+    name: Check for config:system:set usage in shell scripts
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+
+    - name: Check for config:system:set usage
+      run: |
+        ./.github/check-shell-config.sh

--- a/.github/workflows/shell-config-check.yml
+++ b/.github/workflows/shell-config-check.yml
@@ -19,11 +19,11 @@ jobs:
     name: Check for config:system:set usage in shell scripts
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        persist-credentials: false
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
-    - name: Check for config:system:set usage
-      run: |
-        ./.github/check-shell-config.sh
+      - name: Check for config:system:set usage
+        run: |
+          ./.github/check-shell-config.sh

--- a/.github/workflows/shell-formatting.yml
+++ b/.github/workflows/shell-formatting.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Shell Script Formatting Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shell-formatting-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-shell-formatting:
+    runs-on: ubuntu-latest
+    name: Validate shell script formatting
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install editorconfig-checker
+        uses: editorconfig-checker/action-editorconfig-checker@d2ed4fd072ae6f887e9407c909af0f585d2ad9f4 # v2
+        with:
+          version: "v3.6.1"
+
+      - name: Check formatting
+        run: editorconfig-checker
+
+      - name: Show EditorConfig violations for shell files
+        if: failure()
+        run: |
+          echo "❌ EditorConfig violations found in shell files"
+          echo "Expected formatting rules from .editorconfig:"
+          echo "  - charset: utf-8"
+          echo "  - end_of_line: lf"
+          echo "  - indent_size: 2"
+          echo "  - indent_style: tab"
+          echo "  - insert_final_newline: true"
+          echo "  - tab_width: 4"
+          echo ""
+          echo "Please fix the formatting issues in the shell files."

--- a/.github/workflows/shell-formatting.yml
+++ b/.github/workflows/shell-formatting.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 STRATO GmbH
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-name: Shell Script Formatting Check
+name: EditorConfig Formatting Check
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   check-shell-formatting:
     runs-on: ubuntu-latest
-    name: Validate shell script formatting
+    name: Validate repository formatting
 
     steps:
       - name: Checkout code
@@ -32,16 +32,8 @@ jobs:
       - name: Check formatting
         run: editorconfig-checker
 
-      - name: Show EditorConfig violations for shell files
+      - name: Show EditorConfig violations
         if: failure()
         run: |
-          echo "❌ EditorConfig violations found in shell files"
-          echo "Expected formatting rules from .editorconfig:"
-          echo "  - charset: utf-8"
-          echo "  - end_of_line: lf"
-          echo "  - indent_size: 2"
-          echo "  - indent_style: tab"
-          echo "  - insert_final_newline: true"
-          echo "  - tab_width: 4"
-          echo ""
-          echo "Please fix the formatting issues in the shell files."
+          echo "❌ EditorConfig violations found"
+          echo "Please review and fix formatting based on the matching section(s) in .editorconfig."

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
 on:
   pull_request:
 
@@ -9,9 +11,11 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: error
         env:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,5 +18,9 @@ jobs:
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: error
+          ignore_paths: .github/check-shell-config.sh
         env:
           SHELLCHECK_OPTS: --shell sh
+
+      - name: Run ShellCheck for Bash-only helper
+        run: shellcheck --shell bash --severity error .github/check-shell-config.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ### PHP-CS-Fixer template
 # Covers PHP CS Fixer
 # Reference: https://cs.symfony.com/

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 require_once './vendor/autoload.php';
 

--- a/LICENSES/AGPL-3.0-or-later.txt
+++ b/LICENSES/AGPL-3.0-or-later.txt
@@ -1,0 +1,235 @@
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works.  By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.
+
+When we speak of free software, we are referring to freedom, not price.  Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate.  Many developers of free software are heartened and encouraged by the resulting cooperation.  However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.
+
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community.  It requires the operator of a network server to provide the source code of the modified version running there to the users of that server.  Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.
+
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals.  This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License.  Each licensee is addressed as "you".  "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.  The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy.  Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies.  Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License.  If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The "source code" for a work means the preferred form of the work for making modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form.  A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities.  However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work.  For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met.  This License explicitly affirms your unlimited permission to run the unmodified Program.  The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.  This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force.  You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright.  Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below.  Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7.  This requirement modifies the requirement in section 4 to "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy.  This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged.  This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit.  Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source.  This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge.  You need not require recipients to copy the Corresponding Source along with the object code.  If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source.  Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling.  In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage.  For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product.  A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source.  The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information.  But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed.  Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law.  If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it.  (Additional permissions may be written to require their own removal in certain cases when you modify the work.)  You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10.  If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.  If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License.  Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License.  If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program.  Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance.  However, nothing other than this License grants you permission to propagate or modify any covered work.  These actions infringe copyright if you do not accept this License.  Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License.  You are not responsible for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations.  If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License.  For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based.  The work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version.  For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement).  To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License.  You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License.  If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software.  This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work.  The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time.  Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.  If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions.  However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+
+     You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source.  For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code.  There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Kai Henseler <kai.henseler@strato.de>
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Build configuration

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,10 @@
+version = 1
+SPDX-PackageName = "nc IONOS"
+SPDX-PackageSupplier = "STRATO GmbH"
+SPDX-PackageDownloadLocation = "NOASSERTION"
+
+[[annotations]]
+path = ["composer.json", "composer.lock"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2025 STRATO GmbH"
+SPDX-License-Identifier = "AGPL-3.0-or-later"

--- a/apps-disable.sh
+++ b/apps-disable.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # This script assumes to be located in /IONOS as submodule within the Nextcloud server
 # repository.
 

--- a/apps-enable.sh
+++ b/apps-enable.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # This script assumes to be located in /IONOS as submodule within the Nextcloud server
 # repository.
 

--- a/configs/admin_audit.config.php
+++ b/configs/admin_audit.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'log.condition' => [
 		'apps' => ['admin_audit'],

--- a/configs/app-paths.config.php
+++ b/configs/app-paths.config.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 $CONFIG = [
 	'apps_paths' => [
 		[

--- a/configs/defaultapp.config.php
+++ b/configs/defaultapp.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'defaultapp' => 'files',
 ];

--- a/configs/disable-automatic-updates.config.php
+++ b/configs/disable-automatic-updates.config.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2025 STRATO AG
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/configs/disable-automatic-updates.config.php
+++ b/configs/disable-automatic-updates.config.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * SPDX-FileCopyrightText: 2025 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'appstoreenabled' => false,
 ];

--- a/configs/enable-theme.config.php
+++ b/configs/enable-theme.config.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'theme' => 'nc-ionos-theme',
 ];

--- a/configs/initial-files.config.php
+++ b/configs/initial-files.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'skeletondirectory' => '',
 	'templatedirectory' => '',

--- a/configs/ionos-apps-user-agents.config.php
+++ b/configs/ionos-apps-user-agents.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'core.login_flow_v2.allowed_user_agents' => [
 		// Use regex to match the user agent string

--- a/configs/ionos-links.config.php
+++ b/configs/ionos-links.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'ionos_peer_products' => [
 		'ionos_webmail_target_link' => 'https://email.ionos.fr/',

--- a/configs/mail.config.php
+++ b/configs/mail.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	// Disable mailing altogether
 	// Requires Nextcloud server PR #48977

--- a/configs/nc-server.config.php
+++ b/configs/nc-server.config.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+$CONFIG = [
+	// Disable custom lookup server to publish user data
+	'lookup_server' => '',
+];

--- a/configs/oidc.config.php
+++ b/configs/oidc.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'user_oidc' => [
 		'enable_default_claims' => false,

--- a/configs/preview-providers.config.php
+++ b/configs/preview-providers.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'enabledPreviewProviders' => [
 		'OC\Preview\BMP',

--- a/configs/redirects.config.php
+++ b/configs/redirects.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'redirects' => [
 		// Request path without /index.php/ maps to a controller path in the form

--- a/configs/reduce-langs.config.php
+++ b/configs/reduce-langs.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'reduce_to_languages' => [
 		'en',

--- a/configs/server-base.config.php
+++ b/configs/server-base.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'htaccess.RewriteBase' => '/',
 	'forwarded_for_headers' => [ '0' => 'HTTP_X_FORWARDED_FOR' ],

--- a/configs/share-by-mail.config.php
+++ b/configs/share-by-mail.config.php
@@ -1,5 +1,11 @@
 <?php
 
+/*
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	// Enable creating and sending sharelinks via e-mail
 	'sharing.enable_share_mail' => true,

--- a/configs/upgrade.config.php
+++ b/configs/upgrade.config.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2025 STRATO AG
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/configs/upgrade.config.php
+++ b/configs/upgrade.config.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * SPDX-FileCopyrightText: 2025 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 $CONFIG = [
 	'upgrade.disable-web' => true,
 ];

--- a/configure-object-store.sh
+++ b/configure-object-store.sh
@@ -17,27 +17,29 @@ write_config_file() {
 	config="${NEXTCLOUD_ROOT_DIR}/config/object-store.config.php"
 
 	# Note: backslashes require double escaping due to shell (\\ -> \\\\)
-	cat >${config} <<-EOF
-		<?php
-		\$CONFIG = [
-		  // https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html
-		  'objectstore' => [
-		    'class' => '\\\\OC\\\\Files\\\\ObjectStore\\\\S3',
-		    'arguments' => [
-		      'autocreate' => false,
-		      'bucket' => '${ENC_OBJECT_STORAGE_BUCKET_NAME}',
-		      'region' => '${ENC_OBJECT_STORAGE_REGION}',
-		      'hostname' => '${ENC_OBJECT_STORAGE_HOSTNAME}',
-		      'port' => ${ENC_OBJECT_STORAGE_PORT},
-		      'use_ssl' => ${use_ssl_value},
-		      'key' => '${ENC_OBJECT_STORAGE_ACCESS_KEY}',
-		      'secret' => '${ENC_OBJECT_STORAGE_SECRET}',
-		      'objectPrefix' => 'urn:oid:',
-		      'use_path_style' => ${use_path_style_value},
-		    ],
-		  ],
-		];
-	EOF
+	# Heredoc body is at column 0 and uses tabs for PHP indentation to keep
+	# editorconfig-checker happy (the dash-form <<-EOF would strip those tabs).
+	cat >"${config}" <<EOF
+<?php
+\$CONFIG = [
+	// https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html
+	'objectstore' => [
+		'class' => '\\\\OC\\\\Files\\\\ObjectStore\\\\S3',
+		'arguments' => [
+			'autocreate' => false,
+			'bucket' => '${ENC_OBJECT_STORAGE_BUCKET_NAME}',
+			'region' => '${ENC_OBJECT_STORAGE_REGION}',
+			'hostname' => '${ENC_OBJECT_STORAGE_HOSTNAME}',
+			'port' => ${ENC_OBJECT_STORAGE_PORT},
+			'use_ssl' => ${use_ssl_value},
+			'key' => '${ENC_OBJECT_STORAGE_ACCESS_KEY}',
+			'secret' => '${ENC_OBJECT_STORAGE_SECRET}',
+			'objectPrefix' => 'urn:oid:',
+			'use_path_style' => ${use_path_style_value},
+		],
+	],
+];
+EOF
 }
 
 main() {

--- a/configure-object-store.sh
+++ b/configure-object-store.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 NEXTCLOUD_ROOT_DIR="/var/www/html"
 
 # Log fatal error message and exit with failure code

--- a/configure-user-oidc.sh
+++ b/configure-user-oidc.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Log fatal error message and exit with failure code
 # Usage: log_fatal <message>
 log_fatal() {

--- a/configure.sh
+++ b/configure.sh
@@ -8,12 +8,12 @@
 # This script configures a HiDrive Next instance with IONOS-specific settings.
 #
 # Features:
-# - Server basic configuration (lookup server, admin email, search providers)
+# - Server basic configuration (admin email, search providers)
 # - Theming and branding setup for IONOS HiDrive Next
 # - App configuration (viewer, sharing, files, DAV)
 # - Integration setup (IONOS processes, serverinfo, Collabora)
 # - Selective app disabling based on configuration
-# - Configuration partials for app paths
+# - Runtime-safe OCC configuration (system settings like lookup_server are provided via config partials)
 #
 # Environment Variables:
 # - ADMIN_USERNAME: Admin username (default: admin)

--- a/configure.sh
+++ b/configure.sh
@@ -289,39 +289,6 @@ disable_configured_apps() {
 }
 
 #===============================================================================
-# Configuration Setup Functions
-#===============================================================================
-
-# Add HiDrive Next configuration partials for app paths
-# Usage: setup_config_partials
-setup_config_partials() {
-	log_info "Setting up configuration partials..."
-
-	cat >"${SCRIPT_DIR}/../config/app-paths.config.php" <<-'EOF'
-		<?php
-		$CONFIG = [
-		  'apps_paths' => [
-		    [
-		      'path' => '/var/www/html/apps',
-		      'url' => '/apps',
-		      'writable' => true,
-		    ],
-		    [
-		      'path' => '/var/www/html/apps-custom',
-		      'url' => '/apps-custom',
-		      'writable' => true,
-		    ],
-		    [
-		      'path' => '/var/www/html/apps-external',
-		      'url' => '/apps-external',
-		      'writable' => true,
-		    ],
-		  ],
-		];
-	EOF
-}
-
-#===============================================================================
 # Main Execution Function
 #===============================================================================
 
@@ -335,7 +302,6 @@ main() {
 	verify_nextcloud_installation
 
 	# Execute configuration steps
-	setup_config_partials
 	configure_server_basics
 	config_apps
 	configure_theming

--- a/configure.sh
+++ b/configure.sh
@@ -111,7 +111,6 @@ verify_nextcloud_installation() {
 configure_server_basics() {
 	log_info "Configuring HiDrive Next server basics..."
 
-	execute_occ_command config:system:set lookup_server --value=""
 	execute_occ_command user:setting "${ADMIN_USERNAME}" settings email "${ADMIN_EMAIL}"
 	# array of providers to be used for unified search
 	execute_occ_command config:app:set --value '["files"]' --type array core unified_search.providers_allowed

--- a/configure.sh
+++ b/configure.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 #===============================================================================
 # HiDrive Next Configuration Script

--- a/disabled-apps.inc.sh
+++ b/disabled-apps.inc.sh
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # List of apps to be disabled.
 # Managed as include file so that it can be used in various scripts.
 export DISABLED_APPS="activity

--- a/enabled-core-apps.inc.sh
+++ b/enabled-core-apps.inc.sh
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # List of ./apps to be always enabled.
 # Managed as include file so that it can be used in various scripts.
 export ENABLED_CORE_APPS="admin_audit

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <!--
- - SPDX-FileCopyrightText: 2025 STRATO GmbH
- - SPDX-License-Identifier: AGPL-3.0-or-later
+  - SPDX-FileCopyrightText: 2025 STRATO GmbH
+  - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 # IONOS HiDrive Next configuration
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
+<!--
+ - SPDX-FileCopyrightText: 2025 STRATO GmbH
+ - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 # IONOS HiDrive Next configuration
 
 ## Building apps and themes for local development


### PR DESCRIPTION
## Summary

Brings the CI workflows and quality-tooling baseline that has accumulated in the sister repo `IONOS-Productivity/ncw-config` into this repo. Commits are cherry-picked with original authorship/date preserved where possible; nc-server-specific adaptations are authored as fresh commits.

### What's added

**Phase A — CI workflows (no preconditions):**
- `block-unconventional-commits.yml` — gates Conventional Commits on PRs
- `fixup.yml` — blocks `fixup!`/`squash!` commits from merging
- `shell-formatting.yml` + updated `.editorconfig` — editorconfig-checker on shell scripts
- SPDX license headers cherry-pick

**Phase B — Shell config policy:**
- Migrates the single \`config:system:set lookup_server\` call from \`configure.sh\` into a new partial config \`configs/nc-server.config.php\` (loaded automatically by \`add_config_partials\` Makefile target)
- Adds \`shell-config-check.yml\` + \`.github/check-shell-config.sh\` to enforce the no-\`config:system:set\`-in-shell policy

**Phase C — REUSE / SPDX compliance:**
- \`REUSE.toml\` (adapted: \`SPDX-PackageName = \"nc IONOS\"\`, dropped \`IONOS_logo.svg\` annotation since the file doesn't exist here)
- \`LICENSES/{AGPL-3.0-or-later,CC0-1.0,MIT}.txt\`
- SPDX headers across all previously-uncovered tracked files (shell scripts, PHP configs, Makefile, .gitignore, .php-cs-fixer.dist.php)
- \`reuse.yml\` workflow

### Source

Cherry-picked from local \`/home/cr/develop/easycloud/ncw-server/IONOS\` working tree (sister repo, ncw-config upstream). Plan + commit list documented in \`/home/cr/.claude/plans/lets-compare-our-sister-typed-hopper.md\`.

## Test plan

- [ ] CI: \`block-unconventional-commits\` passes (commits in this PR are Conventional Commits — verify)
- [ ] CI: \`fixup\` passes (no fixup commits — verify)
- [ ] CI: \`shellcheck\` continues to pass
- [ ] CI: \`shell-formatting\` (editorconfig-checker) — may surface pre-existing violations; triage in this PR
- [ ] CI: \`shell-config-check\` passes (no \`config:system:set\` remains in shell scripts)
- [ ] CI: \`reuse\` passes (local lint on a clean \`git archive\` checkout already reports 41/41 files compliant)
- [ ] End-to-end \`configure.sh\` run inside the dev container still results in empty \`lookup_server\` (now applied via partial config rather than runtime occ call)