### PR TITLE
feat(config): market-specific URLs via config partial (alt to #118)

### DIFF
--- a/.github/check-config-urls.php
+++ b/.github/check-config-urls.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Validate the market-aware IONOS links config partial.
+ *
+ * For every supported MARKET (plus an unset and an invalid value) this:
+ *  - loads configs/ionos-links.config.php with all PHP notices/warnings promoted
+ *    to failures (catches broken PHP), and
+ *  - asserts every required link key is present and a well-formed https URL.
+ *
+ * The required-key list catches both malformed URLs (e.g. a dropped scheme) and
+ * missing/renamed keys. Format/structure only — no network reachability checks,
+ * to keep CI deterministic. Exits non-zero with a per-offender message on failure.
+ */
+
+const PARTIAL = __DIR__ . '/../configs/ionos-links.config.php';
+
+// Markets to exercise: the five real ones plus the fallback paths.
+const MARKETS = ['FR', 'DE', 'ES', 'UK', 'IT', '', 'INVALID_MARKET'];
+
+// Every key here must resolve to a well-formed https URL for every market.
+// Nested keys are expressed as a path (webmail lives under ionos_peer_products).
+const REQUIRED_URL_KEYS = [
+	['ionos_peer_products', 'ionos_webmail_target_link'],
+	['ionos_help_target_link'],
+	['ionos_customclient_android'],
+	['ionos_customclient_ios'],
+	['ionos_customclient_windows'],
+	['ionos_customclient_macos'],
+	['ionos_customclient_linux'],
+	['ionos_customclient_nautilus'],
+	['ionos_homepage'],
+];
+
+$errors = [];
+
+// Promote any notice/warning raised while loading the partial into a failure.
+set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
+	throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+/**
+ * Load the partial for a given MARKET and return the resulting $CONFIG array.
+ */
+function load_config(string $market): array {
+	putenv($market === '' ? 'MARKET' : "MARKET=$market");
+	$CONFIG = [];
+	include PARTIAL;
+	return $CONFIG;
+}
+
+/**
+ * Resolve a (possibly nested) key path, or null if absent.
+ */
+function dig(array $config, array $path): mixed {
+	$node = $config;
+	foreach ($path as $segment) {
+		if (!is_array($node) || !array_key_exists($segment, $node)) {
+			return null;
+		}
+		$node = $node[$segment];
+	}
+	return $node;
+}
+
+foreach (MARKETS as $market) {
+	$label = $market === '' ? '<unset>' : $market;
+
+	try {
+		$config = load_config($market);
+	} catch (Throwable $e) {
+		$errors[] = sprintf('MARKET=%s: PHP error loading partial: %s', $label, $e->getMessage());
+		continue;
+	}
+
+	foreach (REQUIRED_URL_KEYS as $path) {
+		$name = implode('.', $path);
+		$value = dig($config, $path);
+
+		if (!is_string($value) || $value === '') {
+			$errors[] = sprintf('MARKET=%s: missing or empty URL key "%s"', $label, $name);
+		} elseif (!filter_var($value, FILTER_VALIDATE_URL)) {
+			$errors[] = sprintf('MARKET=%s: key "%s" is not a valid URL: %s', $label, $name, $value);
+		} elseif (parse_url($value, PHP_URL_SCHEME) !== 'https') {
+			$errors[] = sprintf('MARKET=%s: key "%s" is not https: %s', $label, $name, $value);
+		}
+	}
+}
+
+restore_error_handler();
+
+if ($errors !== []) {
+	fwrite(STDERR, "❌ ERROR: config URL validation failed:\n");
+	foreach ($errors as $error) {
+		fwrite(STDERR, "  - $error\n");
+	}
+	exit(1);
+}
+
+echo "✅ SUCCESS: config URL validation passed for markets: " . implode(', ', array_map(
+	static fn (string $m): string => $m === '' ? '<unset>' : $m,
+	MARKETS
+)) . "\n";

--- a/.github/check-config-urls.php
+++ b/.github/check-config-urls.php
@@ -16,9 +16,19 @@
  * The required-key list catches both malformed URLs (e.g. a dropped scheme) and
  * missing/renamed keys. Format/structure only — no network reachability checks,
  * to keep CI deterministic. Exits non-zero with a per-offender message on failure.
+ *
+ * When run inside GitHub Actions (GITHUB_ACTIONS=true) it additionally emits
+ * workflow commands: collapsible per-market groups, inline ::error annotations
+ * pointing at the offending line, and a job-summary table. Outside CI the output
+ * stays plain text.
+ *
+ * @see https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
  */
 
 const PARTIAL = __DIR__ . '/../configs/ionos-links.config.php';
+
+// Repo-relative path used for GitHub annotations (workflow runs from repo root).
+const PARTIAL_REPO_PATH = 'configs/ionos-links.config.php';
 
 // Markets to exercise: the five real ones plus the fallback paths.
 const MARKETS = ['FR', 'DE', 'ES', 'UK', 'IT', '', 'INVALID_MARKET'];
@@ -37,26 +47,66 @@ const REQUIRED_URL_KEYS = [
 	['ionos_homepage'],
 ];
 
-$errors = [];
+$inActions = getenv('GITHUB_ACTIONS') === 'true';
+$partialLines = file(PARTIAL, FILE_IGNORE_NEW_LINES) ?: [];
 
-// Promote any notice/warning raised while loading the partial into a failure.
-set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
-	throw new ErrorException($message, 0, $severity, $file, $line);
-});
+// --- GitHub Actions workflow-command helpers ----------------------------------
 
-/**
- * Load the partial for a given MARKET and return the resulting $CONFIG array.
- */
-function load_config(string $market): array {
-	putenv($market === '' ? 'MARKET' : "MARKET=$market");
-	$CONFIG = [];
-	include PARTIAL;
-	return $CONFIG;
+/** Escape message text: only %, CR and LF need encoding. */
+function gh_escape_data(string $s): string {
+	return str_replace(['%', "\r", "\n"], ['%25', '%0D', '%0A'], $s);
+}
+
+/** Escape a property value: data escapes plus ':' and ','. */
+function gh_escape_prop(string $s): string {
+	return str_replace([':', ','], ['%3A', '%2C'], gh_escape_data($s));
 }
 
 /**
- * Resolve a (possibly nested) key path, or null if absent.
+ * Emit an annotation (error|warning|notice). In CI this is a workflow command;
+ * locally it degrades to a plain bullet line on stderr.
  */
+function gh_issue(bool $inActions, string $level, string $message, ?string $file = null, ?int $line = null, ?string $title = null): void {
+	if (!$inActions) {
+		fwrite(STDERR, "  - $message\n");
+		return;
+	}
+
+	$props = [];
+	if ($file !== null) {
+		$props[] = 'file=' . gh_escape_prop($file);
+	}
+	if ($line !== null) {
+		$props[] = 'line=' . $line;
+	}
+	if ($title !== null) {
+		$props[] = 'title=' . gh_escape_prop($title);
+	}
+	$suffix = $props === [] ? '' : ' ' . implode(',', $props);
+	echo "::{$level}{$suffix}::" . gh_escape_data($message) . "\n";
+}
+
+function gh_group(bool $inActions, string $title): void {
+	echo ($inActions ? "::group::$title" : "▼ $title") . "\n";
+}
+
+function gh_endgroup(bool $inActions): void {
+	if ($inActions) {
+		echo "::endgroup::\n";
+	}
+}
+
+/** 1-based line of the first occurrence of $needle in the partial, or null. */
+function find_line(array $lines, string $needle): ?int {
+	foreach ($lines as $i => $text) {
+		if (str_contains($text, $needle)) {
+			return $i + 1;
+		}
+	}
+	return null;
+}
+
+/** Resolve a (possibly nested) key path, or null if absent. */
 function dig(array $config, array $path): mixed {
 	$node = $config;
 	foreach ($path as $segment) {
@@ -68,13 +118,40 @@ function dig(array $config, array $path): mixed {
 	return $node;
 }
 
+// --- Validation ---------------------------------------------------------------
+
+// Promote any notice/warning raised while loading the partial into a failure.
+set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
+	throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+/** Load the partial for a given MARKET and return the resulting $CONFIG array. */
+function load_config(string $market): array {
+	putenv($market === '' ? 'MARKET' : "MARKET=$market");
+	$CONFIG = [];
+	include PARTIAL;
+	return $CONFIG;
+}
+
+$errors = [];
+$perMarket = [];
+
 foreach (MARKETS as $market) {
 	$label = $market === '' ? '<unset>' : $market;
+	$marketErrors = [];
+
+	gh_group($inActions, "Validate MARKET=$label");
 
 	try {
 		$config = load_config($market);
 	} catch (Throwable $e) {
-		$errors[] = sprintf('MARKET=%s: PHP error loading partial: %s', $label, $e->getMessage());
+		$msg = sprintf('MARKET=%s: PHP error loading partial: %s', $label, $e->getMessage());
+		$marketErrors[] = $msg;
+		echo "  ✗ failed to load partial\n";
+		gh_issue($inActions, 'error', $msg, PARTIAL_REPO_PATH, null, 'Broken config partial');
+		gh_endgroup($inActions);
+		$errors = array_merge($errors, $marketErrors);
+		$perMarket[$label] = $marketErrors;
 		continue;
 	}
 
@@ -83,26 +160,71 @@ foreach (MARKETS as $market) {
 		$value = dig($config, $path);
 
 		if (!is_string($value) || $value === '') {
-			$errors[] = sprintf('MARKET=%s: missing or empty URL key "%s"', $label, $name);
+			$msg = sprintf('MARKET=%s: missing or empty URL key "%s"', $label, $name);
+			$marketErrors[] = $msg;
+			echo "  ✗ $name (missing)\n";
+			gh_issue($inActions, 'error', $msg, PARTIAL_REPO_PATH, null, 'Missing config URL');
 		} elseif (!filter_var($value, FILTER_VALIDATE_URL)) {
-			$errors[] = sprintf('MARKET=%s: key "%s" is not a valid URL: %s', $label, $name, $value);
+			$msg = sprintf('MARKET=%s: key "%s" is not a valid URL: %s', $label, $name, $value);
+			$marketErrors[] = $msg;
+			echo "  ✗ $name ($value)\n";
+			gh_issue($inActions, 'error', $msg, PARTIAL_REPO_PATH, find_line($partialLines, "'$value'"), 'Invalid config URL');
 		} elseif (parse_url($value, PHP_URL_SCHEME) !== 'https') {
-			$errors[] = sprintf('MARKET=%s: key "%s" is not https: %s', $label, $name, $value);
+			$msg = sprintf('MARKET=%s: key "%s" is not https: %s', $label, $name, $value);
+			$marketErrors[] = $msg;
+			echo "  ✗ $name ($value)\n";
+			gh_issue($inActions, 'error', $msg, PARTIAL_REPO_PATH, find_line($partialLines, "'$value'"), 'Insecure config URL');
+		} else {
+			echo "  ✓ $name\n";
 		}
 	}
+
+	gh_endgroup($inActions);
+	$errors = array_merge($errors, $marketErrors);
+	$perMarket[$label] = $marketErrors;
 }
 
 restore_error_handler();
 
+// --- Job summary (GitHub Actions only) ----------------------------------------
+
+$summaryPath = getenv('GITHUB_STEP_SUMMARY');
+if ($summaryPath !== false && $summaryPath !== '') {
+	$md = "## Config URL validation\n\n| Market | Result |\n| --- | --- |\n";
+	foreach ($perMarket as $label => $marketErrors) {
+		$md .= sprintf("| `%s` | %s |\n", $label, $marketErrors === [] ? '✅ ok' : '❌ ' . count($marketErrors) . ' issue(s)');
+	}
+	if ($errors !== []) {
+		$md .= "\n### Issues\n";
+		foreach ($errors as $error) {
+			$md .= "- $error\n";
+		}
+	}
+	@file_put_contents($summaryPath, $md, FILE_APPEND);
+}
+
+// --- Result -------------------------------------------------------------------
+
 if ($errors !== []) {
-	fwrite(STDERR, "❌ ERROR: config URL validation failed:\n");
-	foreach ($errors as $error) {
-		fwrite(STDERR, "  - $error\n");
+	$summary = sprintf('config URL validation failed with %d issue(s)', count($errors));
+	if ($inActions) {
+		gh_issue($inActions, 'error', $summary, null, null, 'Config URL validation');
+	} else {
+		fwrite(STDERR, "❌ ERROR: $summary:\n");
+		foreach ($errors as $error) {
+			fwrite(STDERR, "  - $error\n");
+		}
 	}
 	exit(1);
 }
 
-echo "✅ SUCCESS: config URL validation passed for markets: " . implode(', ', array_map(
+$markets = implode(', ', array_map(
 	static fn (string $m): string => $m === '' ? '<unset>' : $m,
 	MARKETS
-)) . "\n";
+));
+$success = "config URL validation passed for markets: $markets";
+if ($inActions) {
+	gh_issue($inActions, 'notice', $success, null, null, 'Config URL validation');
+} else {
+	echo "✅ SUCCESS: $success\n";
+}

--- a/.github/check-shell-config.sh
+++ b/.github/check-shell-config.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Check for config:system:set usage in shell scripts
+# This script ensures shell scripts don't use system-wide configuration commands
+# which can cause conflicts and instability.
+
+set -e
+
+readonly SCRIPT_NAME="check-shell-config.sh"
+readonly CONFIG_COMMAND="config:system:set"
+readonly SUCCESS_EMOJI="✅"
+readonly ERROR_EMOJI="❌"
+readonly WARNING_EMOJI="🚨"
+readonly FIX_EMOJI="📝"
+readonly CHECKLIST_EMOJI="📋"
+
+# Global variables
+found_violations=0
+temp_file=""
+
+# Cleanup function
+cleanup() {
+		if [[ -n "$temp_file" && -f "$temp_file" ]]; then
+				rm -f "$temp_file"
+		fi
+}
+
+# Set up cleanup trap
+trap cleanup EXIT
+
+# Print success message
+print_success() {
+		echo "$SUCCESS_EMOJI SUCCESS: $1"
+}
+
+# Print error message
+print_error() {
+		echo "$ERROR_EMOJI ERROR: $1"
+}
+
+# Print workflow failure message
+print_workflow_failure() {
+		echo "$ERROR_EMOJI WORKFLOW FAILED: $1"
+}
+
+# Check if shell scripts exist in the workspace
+check_shell_scripts_exist() {
+		if ! find . -name "*.sh" -type f -print -quit | grep -q .; then
+				print_success "No shell script files (.sh) found to check"
+				return 1
+		fi
+		return 0
+}
+
+# Check if file should be skipped
+should_skip_file() {
+		local file="$1"
+		[[ "$(basename "$file")" == "$SCRIPT_NAME" ]]
+}
+
+# Find violations in a file
+find_violations_in_file() {
+		local file="$1"
+
+		# Get lines with config:system:set; should_skip_file already excludes this script
+		grep -n "$CONFIG_COMMAND" "$file" 2>/dev/null || true
+}
+
+# Report violations for a file
+report_violations() {
+		local file="$1"
+		local violations="$2"
+
+		print_error "Found $CONFIG_COMMAND usage in: $file"
+		echo "   Lines containing $CONFIG_COMMAND:"
+
+		echo "$violations" | while IFS=: read -r line_num content; do
+				echo "     Line $line_num: $content"
+		done
+
+		echo ""
+		echo "   $FIX_EMOJI FIX PROPOSAL:"
+		echo "   - Use partial configuration approach instead of $CONFIG_COMMAND"
+		echo "   - Consider using environment variables or app-specific configuration"
+		echo ""
+
+		# Record violation
+		echo "1" >> "$temp_file"
+}
+
+# Process a single shell script file
+process_file() {
+		local file="$1"
+
+		if should_skip_file "$file"; then
+				return 0
+		fi
+
+		echo "Checking file: $file"
+
+		local violations
+		violations=$(find_violations_in_file "$file")
+
+		if [[ -n "$violations" ]]; then
+				report_violations "$file" "$violations"
+		fi
+}
+
+# Count total violations
+count_violations() {
+		if [[ -f "$temp_file" ]]; then
+				wc -l < "$temp_file"
+		else
+				echo "0"
+		fi
+}
+
+# Print final failure report
+print_failure_report() {
+		local violation_count="$1"
+
+		print_workflow_failure "Found $violation_count file(s) with $CONFIG_COMMAND usage"
+		echo ""
+		echo "$WARNING_EMOJI POLICY VIOLATION:"
+		echo "   $CONFIG_COMMAND should be avoided in favor of partial configuration"
+		echo ""
+		echo "$CHECKLIST_EMOJI RECOMMENDED ACTIONS:"
+		echo "   1. Review each occurrence and determine if it's truly necessary"
+		echo "   2. Replace with config:app:set where possible"
+		echo "   3. Use environment variables for dynamic configuration"
+		echo ""
+}
+
+# Main execution function
+main() {
+		echo "Scanning for $CONFIG_COMMAND usage in shell scripts..."
+
+		# Create temporary file for tracking violations
+		temp_file=$(mktemp)
+
+		# Check if any shell scripts exist
+		if ! check_shell_scripts_exist; then
+				exit 0
+		fi
+
+		# Process all shell script files
+		while IFS= read -r -d '' file; do
+				process_file "$file"
+		done < <(find . -name "*.sh" -type f -print0)
+
+		# Count and report violations
+		found_violations=$(count_violations)
+
+		if [[ "$found_violations" -gt 0 ]]; then
+				print_failure_report "$found_violations"
+				exit 1
+		else
+				print_success "No $CONFIG_COMMAND usage found in shell scripts"
+		fi
+}
+
+# Run main function
+main "$@"

--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Config Validation
+
+on:
+    pull_request:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: config-validation-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+    name: Validate config partials (PHP syntax and URLs)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 #v2.31.1
+        with:
+          php-version: '8.3'
+
+      - name: Lint config partials
+        run: |
+          for f in configs/*.config.php; do
+            php -l "$f"
+          done
+
+      - name: Validate config URLs
+        run: php .github/check-config-urls.php

--- a/.github/workflows/shell-config-check.yml
+++ b/.github/workflows/shell-config-check.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 STRATO GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Shell Script Configuration Check
+
+on:
+    pull_request:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: shell-script-config-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+  check-config-system-set:
+    runs-on: ubuntu-latest
+    name: Check for config:system:set usage in shell scripts
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check for config:system:set usage
+        run: |
+          ./.github/check-shell-config.sh

--- a/configs/ionos-links.config.php
+++ b/configs/ionos-links.config.php
@@ -1,17 +1,69 @@
 <?php
 
-$CONFIG = [
-	'ionos_peer_products' => [
-		'ionos_webmail_target_link' => 'https://email.ionos.fr/',
-	],
-	'ionos_help_target_link' => 'https://wl.hidrive.com/easy/0027',
-	'ionos_customclient_windows' => 'https://wl.hidrive.com/easy/0003',
-	'ionos_customclient_macos' => 'https://wl.hidrive.com/easy/1003',
-	'ionos_customclient_android' => 'https://wl.hidrive.com/easy/0022',
-	'ionos_customclient_ios' => 'https://wl.hidrive.com/easy/0021',
-	'ionos_customclient_ios_appid' => '6738140194',
-	'ionos_customclient_linux' => 'https://wl.hidrive.com/easy/2003',
-	'ionos_customclient_nautilus' => 'https://wl.hidrive.com/easy/2004',
-	'ionos_homepage' => 'https://ionos.fr/',
-	'simpleSignUpLink.shown' => false,
-];
+$CONFIG = (static function (): array {
+	$market = strtoupper((string)getenv('MARKET'));
+
+	$marketLinks = [
+		'FR' => [
+			'ionos_peer_products' => [
+				'ionos_webmail_target_link' => 'https://email.ionos.fr/',
+			],
+			'ionos_help_target_link' => 'https://wl.hidrive.com/easy/0027',
+			'ionos_customclient_android' => 'https://wl.hidrive.com/easy/0022',
+			'ionos_customclient_ios' => 'https://wl.hidrive.com/easy/0021',
+			'ionos_homepage' => 'https://ionos.fr/',
+		],
+		'DE' => [
+			'ionos_peer_products' => [
+				'ionos_webmail_target_link' => 'https://email.ionos.de/',
+			],
+			'ionos_help_target_link' => 'https://wl.hidrive.com/easy/0047',
+			'ionos_customclient_android' => 'https://wl.hidrive.com/easy/0002',
+			'ionos_customclient_ios' => 'https://wl.hidrive.com/easy/0001',
+			'ionos_homepage' => 'https://ionos.de/',
+		],
+		'ES' => [
+			'ionos_peer_products' => [
+				'ionos_webmail_target_link' => 'https://email.ionos.es/',
+			],
+			'ionos_help_target_link' => 'https://wl.hidrive.com/easy/0017',
+			'ionos_customclient_android' => 'https://wl.hidrive.com/easy/0032',
+			'ionos_customclient_ios' => 'https://wl.hidrive.com/easy/0031',
+			'ionos_homepage' => 'https://ionos.es/',
+		],
+		'UK' => [
+			'ionos_peer_products' => [
+				'ionos_webmail_target_link' => 'https://email.ionos.co.uk/',
+			],
+			'ionos_help_target_link' => 'https://wl.hidrive.com/easy/0007',
+			'ionos_customclient_android' => 'https://wl.hidrive.com/easy/0012',
+			'ionos_customclient_ios' => 'https://wl.hidrive.com/easy/0011',
+			'ionos_homepage' => 'https://ionos.co.uk/',
+		],
+		'IT' => [
+			'ionos_peer_products' => [
+				'ionos_webmail_target_link' => 'https://email.ionos.it/',
+			],
+			'ionos_help_target_link' => 'https://wl.hidrive.com/easy/0037',
+			'ionos_customclient_android' => 'https://wl.hidrive.com/easy/0033',
+			'ionos_customclient_ios' => 'https://wl.hidrive.com/easy/00311',
+			'ionos_homepage' => 'https://ionos.it/',
+		],
+	];
+
+	if (!isset($marketLinks[$market])) {
+		if ($market !== '') {
+			error_log(sprintf('MARKET invalid (%s), defaulting to DE links', $market));
+		}
+		$market = 'DE';
+	}
+
+	return array_merge([
+		'ionos_customclient_windows' => 'https://wl.hidrive.com/easy/0003',
+		'ionos_customclient_macos' => 'https://wl.hidrive.com/easy/1003',
+		'ionos_customclient_ios_appid' => '6738140194',
+		'ionos_customclient_linux' => 'https://wl.hidrive.com/easy/2003',
+		'ionos_customclient_nautilus' => 'https://wl.hidrive.com/easy/2004',
+		'simpleSignUpLink.shown' => false,
+	], $marketLinks[$market]);
+})();

--- a/configs/nc-server.config.php
+++ b/configs/nc-server.config.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 STRATO GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+$CONFIG = [
+	// Disable custom lookup server to avoid publishing user data
+	'lookup_server' => '',
+];

--- a/configure.sh
+++ b/configure.sh
@@ -32,6 +32,17 @@ config_server() {
 	ooc config:app:set --value '["files"]' --type array core unified_search.providers_allowed
 }
 
+log_market_config() {
+	# IONOS links are applied declaratively via the config partials. Read them back
+	# here (config:system:get only) so the resulting MARKET and URLs show up in the
+	# pod log for troubleshooting.
+	echo "MARKET=${MARKET:-<unset>} — effective IONOS links:"
+	echo "  ionos_webmail_target_link = $(ooc config:system:get ionos_peer_products ionos_webmail_target_link)"
+	for _key in ionos_help_target_link ionos_customclient_android ionos_customclient_ios ionos_homepage; do
+		echo "  ${_key} = $(ooc config:system:get "${_key}")"
+	done
+}
+
 config_ui() {
 	echo "Configure theming"
 
@@ -221,6 +232,7 @@ main() {
 	config_server
 	config_apps
 	config_ui
+	log_market_config
 	disable_apps
 }
 

--- a/configure.sh
+++ b/configure.sh
@@ -27,7 +27,6 @@ checks() {
 config_server() {
 	echo "Configure NextCloud basics"
 
-	ooc config:system:set lookup_server --value=""
 	ooc user:setting "${ADMIN_USERNAME}" settings email "${ADMIN_EMAIL}"
 	# array of providers to be used for unified search
 	ooc config:app:set --value '["files"]' --type array core unified_search.providers_allowed


### PR DESCRIPTION
## Alternative to #118 — market URLs via config partial

PR #118 sets market-specific IONOS URLs imperatively in `configure.sh` through a
`set_market_links()` bash `case` that calls `ooc config:system:set ...`. This branch
proposes a declarative alternative and aligns with the no-`config:system:set` policy
already adopted on `master`.

### What changes
- **`configs/ionos-links.config.php`** is now market-aware: it resolves the `MARKET`
  pod env var and returns the matching links (FR/DE/ES/UK/IT, DE fallback for
  unset/invalid). Single declarative source of truth, evaluated per request — no
  imperative `occ` writes, no persisted-state drift. The logic is wrapped in an IIFE so
  only `$CONFIG` enters Nextcloud's config-loader scope, and `ionos_webmail_target_link`
  stays nested under `ionos_peer_products` (as the theme reads it).
- **Adopt the shell-config check** (cherry-picked from `master`: `a7a6bd0`, `cf4ae3a`) —
  CI fails on any `config:system:set` in shell scripts.
- **Drop the last `config:system:set`**: `lookup_server` moves to a new
  `configs/nc-server.config.php` (replicating master `3c1cd2e`), so the check passes.
- **`log_market_config()`** in `configure.sh` logs `MARKET` and the *effective* links
  (read-only `config:system:get`) for pod-log troubleshooting.
- **New `config-validation` workflow** (`.github/check-config-urls.php`): loads the
  partial for every market with PHP notices promoted to failures, and asserts each
  required link key is a well-formed `https` URL — catching broken PHP, dropped
  schemes, and missing/renamed keys.

### Verification
- `./.github/check-shell-config.sh` → passes (no `config:system:set` in shell).
- `php -l` on all `configs/*.config.php`.
- Per-market resolution verified (webmail nesting + client links); unset/invalid → DE.
- `php .github/check-config-urls.php` passes, and was confirmed to fail on a broken URL
  and a missing key.

Closes the approach discussion on #118 (does not auto-close the PR).
