### PR TITLE
feat: backport LoginFlowV2 OIDC config into v30 (HDNEXT-1914)

### DIFF
--- a/configs/oidc.config.php
+++ b/configs/oidc.config.php
@@ -24,5 +24,11 @@ $CONFIG = [
 		//
 		// https://github.com/nextcloud/user_oidc?tab=readme-ov-file#soft-auto-provisioning-without-user-creation
 		'disable_account_creation' => true,
+		// IONOS access tokens carry aud=ionos.com, not per-client values;
+		// audience check must be off (permanent)
+		'selfencoded_bearer_validation_audience_check' => false,
+		// Enable UserInfo fallback for mappingUid claim resolution
+		// (IONOS access tokens lack the claim; permanent per AD-7, CISOLOGIN-902)
+		'userinfo_bearer_validation' => true,
 	],
 ];

--- a/configure-user-oidc.sh
+++ b/configure-user-oidc.sh
@@ -18,7 +18,8 @@ configure_user_oidc() {
 		--extra-claims="${ENC_OIDC_EXTRA_CLAIMS}" \
 		--mapping-uid="${ENC_OIDC_MAPPING_UID}" \
 		--unique-uid=0 \
-		--scope="${ENC_OIDC_SCOPES}"
+		--scope="${ENC_OIDC_SCOPES}" \
+		--check-bearer=1
 
 	# Don't show a login page, send users directly to the ID provider
 	./occ config:app:set --value=0 user_oidc allow_multiple_user_backends


### PR DESCRIPTION
## Summary

Backports LoginFlowV2 bearer-auth configuration from `master` into `ionos-dev-v30` as required by HDNEXT-1914 (original work: HDNEXT-1714).

- Cherry-pick `e881b3c` → `configure-user-oidc.sh`: add `--check-bearer=1` to the `occ user_oidc:provider` call to enable bearer token checking
- Cherry-pick `ecde9e2` → `configs/oidc.config.php`: add two permanent bearer-auth keys:
  - `selfencoded_bearer_validation_audience_check => false` — IONOS access tokens carry `aud=ionos.com` (not per-client); audience check must be off (permanent per CISOLOGIN-902)
  - `userinfo_bearer_validation => true` — enables UserInfo fallback for `mappingUid` claim resolution since IONOS access tokens don't carry that claim (permanent per AD-7)

## Test plan

- [ ] Verify `configs/oidc.config.php` contains both new keys
- [ ] After image roll: `sudo -u www-data php /var/www/html/occ config:system:get --output=json user_oidc | tail -1` should show 7 keys including `selfencoded_bearer_validation_audience_check` and `userinfo_bearer_validation`